### PR TITLE
fix arm64 image build and devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,7 @@
 		"ghcr.io/microsoft/azure-orbital-space-sdk/spacefx-dev:0.11.0": {
 			"app_name": "app-healthcheck",
 			"dev_language": "python",
+			"extra_packages": "libgdal-dev, libgl1",
 			"auto_inject_python_dev_dependencies": "true"
 		}
 	},

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Outputs:
     cd -
     ```
 
-1. Build the nuget packages and the container images.  (Note: container images will automatically push)
+1. Build the nuget packages and the container images.
 
     ```bash
     # clone this repo
@@ -48,7 +48,7 @@ Outputs:
     sudo cp ./schedules/* /var/spacedev/yamls/apps/app-healthcheck/
     ```
 
-1. Push the artifacts to the container registry
+1. Push the artifacts to the container registry. Perform the same steps for building in arm64, but replace with `--architecture arm64`.
 
     ```bash
     # Push the yamls and schedules to the container registry


### PR DESCRIPTION
Adds back necessary packages to devcontainer.json to satisfy pyproject.toml install dependencies.

Re-enables arm64 devcontainers and image builds.